### PR TITLE
docs: remove extra colon from Textarea

### DIFF
--- a/docs/pages/textarea.tsx
+++ b/docs/pages/textarea.tsx
@@ -65,7 +65,7 @@ const demoList = [
       {
         name: "textarea.tsx",
         code: `<div className="flex flex-wrap w-full p-8 space-x-4">
-  <Textarea invalid placeholder="jon@gmail.com" />;
+  <Textarea invalid placeholder="jon@gmail.com" />
 </div>`,
         readOnly: false,
       },


### PR DESCRIPTION
It fixes the `Invalid state` example:

![image](https://user-images.githubusercontent.com/13774309/124705301-bc27a280-def5-11eb-93cc-077d3a190751.png)
