### PR TITLE
docs: property name correction

### DIFF
--- a/docs/pages/theming.mdx
+++ b/docs/pages/theming.mdx
@@ -72,7 +72,7 @@ const cool: ColorScheme = {
       fill: colors.coolGray["900"],
     },
     text: {
-      base: colors.coolGray["100"],
+      foreground: colors.coolGray["100"],
       muted: colors.coolGray["300"],
     },
     primary: colors.cyan,


### PR DESCRIPTION
`base` -> `foreground`